### PR TITLE
Fix: backtick code display

### DIFF
--- a/assets/js/quiz-twig.js
+++ b/assets/js/quiz-twig.js
@@ -84,14 +84,18 @@ function generateQuestionHTML(question, index) {
 }
 
 function escapeHTML(text) {
-    return text
+    let escaped = text
         .replace(/&/g, "&amp;")
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;")
         .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#039;")
-    ;
+        .replace(/'/g, "&#039;");
+    
+    escaped = escaped.replace(/`([^`]+)`/g, "<code class='bg-gray-100 text-red-600 font-mono px-1 rounded'>$1</code>");
+
+    return escaped;
 }
+
 
 function checkResponses() {
     let counter = 0;

--- a/assets/js/quiz_symfony.js
+++ b/assets/js/quiz_symfony.js
@@ -331,13 +331,16 @@ function generateQuestionHTML(question, index) {
 }
 
 function escapeHTML(text) {
-    return text
+    let escaped = text
         .replace(/&/g, "&amp;")
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;")
         .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#039;")
-        ;
+        .replace(/'/g, "&#039;");
+    
+    escaped = escaped.replace(/`([^`]+)`/g, "<code class='bg-gray-100 text-red-600 font-mono px-1 rounded'>$1</code>");
+
+    return escaped;
 }
 
 function checkResponses() {

--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@
                 @apply bg-gray-800 text-white p-4 text-center mt-10 rounded-t-lg shadow-md;
             }
         }
+        code {
+            @apply bg-gray-100 text-red-600 font-mono px-1 rounded;
+        }
     </style>
 </head>
 <body class="bg-gray-50 px-2 sm:px-4">


### PR DESCRIPTION
This pull request includes changes to improve the handling of HTML escaping and styling of code elements in the quiz application. The most important changes include updating the `escapeHTML` function to format inline code and adding styles for code elements.

Improvements to HTML escaping and formatting:

* [`assets/js/quiz_symfony.js`](diffhunk://#diff-998c93f59dfd142b799f4ae6a1051f50d67954c0e2a7afc3035da6bb966cf237L334-R343): Modified the `escapeHTML` function to include formatting for inline code blocks using backticks.

Styling updates:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R35-R37): Added CSS styles for `code` elements to improve their appearance.

Result:
![image](https://github.com/user-attachments/assets/55729957-c436-4e45-a5e6-0f43565a3f2f)
