### PR TITLE
add bottom space index & quiz

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,15 @@
     <title>Test Categories</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <style type="text/tailwindcss">
+      html, body {
+        height: 100%;
+      }
       body {
         font-family: "Arial", sans-serif;
         background-color: #f8fafc;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
       }
       @layer components {
         .btn-primary {
@@ -25,18 +31,19 @@
         }
 
         .footer {
-          @apply bg-gray-800 text-white p-4 text-center mt-10 rounded-t-lg shadow-md;
+          @apply bg-gray-800 text-white p-4 text-center rounded-t-lg shadow-md mt-8;
         }
       }
     </style>
   </head>
   <body class="bg-gray-50 px-2 sm:px-4">
+    <main class="flex-1 flex flex-col">
     <header class="header">
       <h1 class="text-5xl font-bold">Training</h1>
       <p class="mt-2 text-lg">Select a category to start training</p>
     </header>
 
-    <div class="container mx-auto mt-8 px-4">
+    <div class="container mx-auto mt-8 mb-8 px-4">
       <div class="text-center mb-10">
         <a href="quizz_docker.html" class="btn-primary">General Training</a>
       </div>
@@ -80,6 +87,7 @@
         </div>
       </div>
     </div>
+    </main>
 
     <footer class="footer">
       <p>Contribute to improve the questionnaires:</p>

--- a/quizz_docker.html
+++ b/quizz_docker.html
@@ -13,7 +13,7 @@
     <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M5HHV7GC"
             height="0" width="0" style="display:none;visibility:hidden"></iframe>
 </noscript>
-<div class="max-w-xl sm:max-w-6xl mx-auto bg-white px-3 sm:px-6 py-6 rounded-lg shadow-lg">
+<div class="max-w-xl sm:max-w-6xl mx-auto bg-white px-3 sm:px-6 py-6 rounded-b-lg shadow-lg pb-16">
     <h1 id="quiz-title" class="text-2xl font-bold mb-4 text-center"></h1>
     <div id="score" class="text-xl text-center m-4"></div>
     <form id="quiz-form">


### PR DESCRIPTION
https://github.com/efficience-it/efficience-it.github.io/issues/10

Added space at the bottom of the quiz and between the footer and page elements on the index for improved readability 

<img width="1334" height="430" alt="Capture d&#39;écran 2026-01-29 165447" src="https://github.com/user-attachments/assets/e9927685-9bd4-44bb-a890-84bb725ca17e" />

<img width="1334" height="772" alt="image" src="https://github.com/user-attachments/assets/5d6d6670-c7f5-4822-9541-707bac5be558" />
