### PR TITLE
fix: set lang attribute to "en" on quizz_docker.html

### DIFF
--- a/quizz_docker.html
+++ b/quizz_docker.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
     <script src="assets/js/gtag.js"></script>
     <meta charset="UTF-8">


### PR DESCRIPTION
The page content is in English but the lang attribute was set to "fr", which impacts screen readers and browser spellchecking.