### PR TITLE
fix: set lang attribute to en on quizz_docker.html

### DIFF
--- a/quizz_docker.html
+++ b/quizz_docker.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
     <script src="assets/js/gtag.js"></script>
     <meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- Replace `lang="fr"` with `lang="en"` on `quizz_docker.html` since all content is in English
- Fixes screen reader language detection and browser spellchecking

## Test plan
- [ ] Open `quizz_docker.html` and inspect the `<html>` tag to verify `lang="en"`
- [ ] Verify browser spellcheck uses English dictionary