### PR TITLE
fix: add padding to prevent fixed bar from overlapping content

### DIFF
--- a/quizz_docker.html
+++ b/quizz_docker.html
@@ -17,7 +17,7 @@
     <h1 id="quiz-title" class="text-2xl font-bold mb-4 text-center"></h1>
     <div id="score" class="text-xl text-center m-4"></div>
     <form id="quiz-form">
-        <div id="questions-container"></div>
+        <div id="questions-container" class="pb-16"></div>
         <div class="fixed bottom-0 left-0 w-full bg-white shadow-lg p-2 flex justify-center space-x-2">
             <button type="button" id="restart-quiz"
                     class="px-4 py-2 bg-blue-600 text-white font-medium rounded-md shadow hover:bg-blue-700 transition duration-300 text-sm">


### PR DESCRIPTION
The fixed bottom bar was covering the last quiz question. Adding pb-16 to the questions container compensates for the bar height.