### PR TITLE
refactor: cleanup code and fix shuffle, score, getQueryParam

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,8 +1,11 @@
+function getQueryParam(param) {
+    return new URLSearchParams(window.location.search).get(param);
+}
+
 document.getElementById("restart-quiz").addEventListener("click", function() {
-    const url = new URL(window.location.href);
-    const topic = url.searchParams.get("topic");
+    const topic = getQueryParam("topic");
     if (topic) {
-        window.location.href = url.pathname + "?topic=" + topic;
+        window.location.href = window.location.pathname + "?topic=" + topic;
     } else {
         location.reload();
     }

--- a/assets/js/quizz_docker.js
+++ b/assets/js/quizz_docker.js
@@ -1,3 +1,13 @@
+const MAX_QUESTIONS = 20;
+
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
 const quizTopics = {
   orchestration: {
     title: "Quizz DCA - Orchestration",
@@ -111,10 +121,6 @@ const quizTopics = {
   },
 };
 
-function getQueryParam(param) {
-  return new URLSearchParams(window.location.search).get(param);
-}
-
 async function fetchQuestionsFromTopics(topics, questionsPerTopic = null) {
   const baseUrl =
     "https://raw.githubusercontent.com/efficience-it/docker-practice/refs/heads/v1.5/";
@@ -131,9 +137,7 @@ async function fetchQuestionsFromTopics(topics, questionsPerTopic = null) {
         return {
           topic,
           questions: questionsPerTopic
-            ? topicQuestions
-                .sort(() => Math.random() - 0.5)
-                .slice(0, questionsPerTopic)
+            ? shuffleArray(topicQuestions).slice(0, questionsPerTopic)
             : topicQuestions,
         };
       }),
@@ -199,10 +203,8 @@ function displayQuestions(questions) {
   const container = document.getElementById("questions-container");
   container.innerHTML = "";
 
-  questions
-    .sort(() => Math.random() - 0.5)
-    .slice(0, 20)
-    .forEach((question, index) => {
+  shuffleArray(questions);
+  questions.slice(0, MAX_QUESTIONS).forEach((question, index) => {
       container.innerHTML += generateQuestionHTML(question, index);
     });
 
@@ -238,7 +240,7 @@ function generateQuestionHTML(question, index) {
   const inputType =
     answers.filter((a) => a.correct).length > 1 ? "checkbox" : "radio";
 
-  const shuffledAnswers = [...answers].sort(() => Math.random() - 0.5);
+  const shuffledAnswers = shuffleArray([...answers]);
 
   const optionsHTML = shuffledAnswers
     .map(
@@ -280,7 +282,8 @@ function escapeHTML(text) {
 
 function checkResponses() {
   let counter = 0;
-  document.querySelectorAll(".question-body").forEach((questionBlock) => {
+  const questionBlocks = document.querySelectorAll(".question-body");
+  questionBlocks.forEach((questionBlock) => {
     const questionHeader = questionBlock
       .closest(".mb-4")
       .querySelector(".question-header");
@@ -308,7 +311,7 @@ function checkResponses() {
 
     if (isCorrect) counter++;
   });
-  document.getElementById("score").textContent = `${counter}/20`;
+  document.getElementById("score").textContent = `${counter}/${questionBlocks.length}`;
 }
 
 const topic = getQueryParam("topic");

--- a/quizz_docker.html
+++ b/quizz_docker.html
@@ -44,7 +44,7 @@
         </div>
     </form>
 </div>
-<script src="./assets/js/quizz_docker.js"></script>
 <script src="./assets/js/common.js"></script>
+<script src="./assets/js/quizz_docker.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace biased `.sort(() => Math.random() - 0.5)` with proper Fisher-Yates `shuffleArray()` function
- Replace hardcoded `/20` score display with dynamic question count
- Centralize `getQueryParam()` in `common.js`, removing duplication from `quizz_docker.js`
- Extract `MAX_QUESTIONS` constant to replace magic number `20`
- Swap script load order so `common.js` loads before `quizz_docker.js`

## Test plan
- [ ] Open index.html, select any topic, verify quiz loads correctly
- [ ] Verify General Training mode still works
- [ ] Validate answers and check score displays as `X/<actual count>`
- [ ] Verify answers are properly shuffled each reload
- [ ] Verify Restart button still works