### PR TITLE
feat: add progress bar for answered questions

### DIFF
--- a/assets/js/quizz_docker.js
+++ b/assets/js/quizz_docker.js
@@ -206,6 +206,25 @@ function displayQuestions(questions) {
       container.innerHTML += generateQuestionHTML(question, index);
     });
 
+  // Progress tracking
+  const totalQuestions = container.querySelectorAll(".question-body").length;
+  const progressText = document.getElementById("progress-text");
+  const progressBar = document.getElementById("progress-bar");
+  progressText.textContent = `0/${totalQuestions} answered`;
+  progressBar.style.width = "0%";
+
+  container.addEventListener("change", function () {
+    const questionBlocks = container.querySelectorAll(".question-body");
+    let answered = 0;
+    questionBlocks.forEach((block) => {
+      if (block.querySelector(".answers-container input:checked")) {
+        answered++;
+      }
+    });
+    progressText.textContent = `${answered}/${totalQuestions} answered`;
+    progressBar.style.width = `${(answered / totalQuestions) * 100}%`;
+  });
+
   // Ecouteur pour copier l'UUID
   container.querySelectorAll(".copy-uuid").forEach((el) => {
     el.addEventListener("click", function () {

--- a/quizz_docker.html
+++ b/quizz_docker.html
@@ -26,6 +26,14 @@
 <div class="max-w-xl sm:max-w-6xl mx-auto bg-white px-3 sm:px-6 py-6 rounded-b-lg shadow-lg pb-16">
     <h1 id="quiz-title" class="text-2xl font-bold mb-4 text-center"></h1>
     <div id="score" class="text-xl text-center m-4"></div>
+    <div id="progress" class="mb-4">
+        <div class="flex justify-between text-sm text-gray-600 mb-1">
+            <span id="progress-text">0/0 answered</span>
+        </div>
+        <div class="w-full bg-gray-200 rounded h-2">
+            <div id="progress-bar" class="bg-blue-600 h-2 rounded transition-all duration-300" style="width: 0%"></div>
+        </div>
+    </div>
     <form id="quiz-form">
         <div id="questions-container" class="pb-16"></div>
         <div class="fixed bottom-0 left-0 w-full bg-white shadow-lg p-2 flex justify-center space-x-2">


### PR DESCRIPTION
## Summary
- Add a progress indicator above the quiz questions showing "X/N answered"
- Display a blue Tailwind progress bar (`bg-blue-600 h-2 rounded`) that fills as questions are answered
- A question counts as "answered" when at least one radio/checkbox is checked
- Updates dynamically on every input change

## Test plan
- [ ] Open any quiz topic, verify progress bar starts at "0/N answered"
- [ ] Answer questions one by one, verify counter increments and bar fills
- [ ] Verify bar reaches 100% when all questions are answered
- [ ] Test on mobile for responsive layout
- [ ] Verify General Training mode also shows correct total