### PR TITLE
feat: add quiz header with back navigation

### DIFF
--- a/quizz_docker.html
+++ b/quizz_docker.html
@@ -23,8 +23,16 @@
     <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M5HHV7GC"
             height="0" width="0" style="display:none;visibility:hidden"></iframe>
 </noscript>
+<header class="bg-gray-800 text-white p-4 text-center rounded-b-lg shadow-md mb-0">
+    <div class="max-w-xl sm:max-w-6xl mx-auto flex items-center justify-between">
+        <a href="index.html" class="text-gray-300 hover:text-white text-sm flex items-center gap-1">
+            ← Back to categories
+        </a>
+        <h1 id="quiz-title" class="text-xl sm:text-2xl font-bold"></h1>
+        <span class="w-32"></span>
+    </div>
+</header>
 <div class="max-w-xl sm:max-w-6xl mx-auto bg-white px-3 sm:px-6 py-6 rounded-b-lg shadow-lg pb-16">
-    <h1 id="quiz-title" class="text-2xl font-bold mb-4 text-center"></h1>
     <div id="score" class="text-xl text-center m-4"></div>
     <form id="quiz-form">
         <div id="questions-container" class="pb-16"></div>
@@ -37,10 +45,6 @@
                     class="px-4 py-2 bg-green-600 text-white font-medium rounded-md shadow hover:bg-green-700 transition duration-300 text-sm">
                 ✅ Validate
             </button>
-            <a href="https://efficience-it.github.io"
-               class="px-4 py-2 bg-red-600 text-white font-medium rounded-md shadow hover:bg-red-700 transition duration-300 text-sm">
-                ❌ Cancel
-            </a>
         </div>
     </form>
 </div>


### PR DESCRIPTION
## Summary
- Add a dark header bar (matching `index.html` style) to the quiz page with a "Back to categories" link and the quiz title
- Remove the redundant "Cancel" button from the fixed bottom bar, since the header now provides navigation back to the homepage

## Test plan
- [ ] Open any quiz topic, verify header shows topic title and "Back to categories" link
- [ ] Click "Back to categories" link, verify it navigates to index.html
- [ ] Verify the Cancel button is no longer in the bottom bar
- [ ] Verify Restart and Validate buttons still work
- [ ] Test on mobile for responsive header layout