### PR TITLE
Add Docker® trademark compliance notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,6 @@ All contributions must remain original and educational.
 ## ⚖️ Legal Notice
 
 * This is a **community-driven, unofficial project**.
-* It is **not sponsored or endorsed** by Docker Inc., Mirant*
+* It is **not sponsored or endorsed** by Docker Inc., Mirantis, or any of their affiliates.
+* All trademarks are the property of their respective owners.
+* Docker® and the Docker® logo are trademarks or registered trademarks of Docker, Inc. in the United States and/or other countries. Docker, Inc. and other parties may also hold trademark rights to other terms used in this document.

--- a/index.html
+++ b/index.html
@@ -100,9 +100,10 @@
       <a
         href="https://github.com/efficience-it/docker-practice"
         class="text-blue-400 hover:underline"
-        >Docker Questions</a
+        >Docker® Questions</a
       >
       |
+      <p class="mt-2 text-xs text-gray-400">Docker® and the Docker® logo are trademarks or registered trademarks of Docker, Inc. in the United States and/or other countries.</p>
     </footer>
   </body>
 </html>

--- a/quizz_docker.html
+++ b/quizz_docker.html
@@ -4,7 +4,7 @@
     <script src="assets/js/gtag.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title id="page-title">Quiz Docker</title>
+    <title id="page-title">Quiz Docker®</title>
     <script src="https://cdn.tailwindcss.com/3.4.16"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
     <style>


### PR DESCRIPTION
## Summary
- Fix truncated legal notice in README.md (was cut off at "Mirant*")
- Add Docker® registered trademark symbol (®) in user-facing text (footer, page title)
- Add Docker trademark disclaimer in footer (`index.html`) and README

## Context
Compliance with Docker trademark guidelines (https://www.docker.com/legal/trademark-guidelines/).