### PR TITLE
feat: show error message to user on network failure (#27)

### DIFF
--- a/assets/js/quizz_docker.js
+++ b/assets/js/quizz_docker.js
@@ -168,6 +168,7 @@ async function fetchQuestionsFromTopics(topics, questionsPerTopic = null) {
     return allQuestionsByTopic.flatMap(({ questions }) => questions);
   } catch (error) {
     console.error("Error loading questions:", error);
+    displayError("Failed to load questions.");
     return [];
   }
 }
@@ -219,7 +220,11 @@ function updatePageTitles(title) {
 
 function displayError(message) {
   document.getElementById("questions-container").innerHTML =
-    `<p class='text-red-600'>${message}</p>`;
+    `<div class="flex flex-col items-center justify-center py-20 text-center">
+      <p class="text-red-600 font-medium mb-2">${message}</p>
+      <p class="text-gray-500 text-sm mb-4">Please check your connection and try again.</p>
+      <button onclick="location.reload()" class="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition duration-200">Reload</button>
+    </div>`;
 }
 
 function displayQuestions(questions) {


### PR DESCRIPTION
## Summary
- Replace blank page on fetch failure with a styled error message
- Add a "Reload" button for easy retry
- Display error from `fetchQuestionsFromTopics` catch block too

## Test plan
- [ ] Disconnect network, open quiz → error message with reload button appears
- [ ] Click "Reload" → page reloads

Closes #27