### PR TITLE
feat: add dark mode support (#28)

### DIFF
--- a/assets/js/quizz_docker.js
+++ b/assets/js/quizz_docker.js
@@ -295,8 +295,8 @@ function generateQuestionHTML(question, index) {
     .join("");
 
   return `
-                <div class="mb-4 p-4 border rounded-lg bg-gray-50">
-                    <h5 class="question-header flex justify-between items-center font-semibold text-gray-700" 
+                <div class="mb-4 p-4 border rounded-lg bg-gray-50 dark:bg-gray-800">
+                    <h5 class="question-header flex justify-between items-center font-semibold text-gray-700 dark:text-gray-200" 
                         data-answers='${escapeHTML(JSON.stringify(answers.filter((a) => a.correct).map((a) => a.value)))}'>
                         <span class="question-header-title">${escapeHTML(question.question)}</span>
                         <span class="copy-uuid self-end text-sm text-gray-500 cursor-pointer hover:text-gray-700" 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <script src="https://cdn.tailwindcss.com/3.4.16"></script>
     <script>
       tailwind.config = {
+        darkMode: 'class',
         theme: {
           extend: {
             fontFamily: {
@@ -35,24 +36,33 @@
         }
 
         .card {
-          @apply text-center bg-white border border-gray-200 rounded-xl p-6 hover:border-indigo-300 transition duration-200;
+          @apply text-center bg-white border border-gray-200 rounded-xl p-6 hover:border-indigo-300 transition duration-200 dark:bg-gray-800 dark:border-gray-700 dark:hover:border-indigo-500 dark:text-gray-200;
         }
 
         .header {
-          @apply bg-white border-b border-gray-200 p-8 text-center;
+          @apply bg-white border-b border-gray-200 p-8 text-center dark:bg-gray-900 dark:border-gray-700;
         }
 
         .footer {
-          @apply border-t border-gray-100 p-6 text-center mt-auto;
+          @apply border-t border-gray-100 p-6 text-center mt-auto dark:border-gray-700;
         }
       }
     </style>
   </head>
-  <body class="bg-stone-50 px-2 sm:px-4 font-sans">
+  <body class="bg-stone-50 dark:bg-gray-900 px-2 sm:px-4 font-sans dark:text-gray-200">
     <main class="flex-1 flex flex-col">
     <header class="header">
-      <h1 class="text-3xl font-semibold tracking-tight text-gray-900">Training</h1>
-      <p class="mt-2 text-base text-gray-500">Select a category to start training</p>
+      <div class="flex items-center justify-between max-w-3xl mx-auto">
+        <span></span>
+        <div class="text-center">
+          <h1 class="text-3xl font-semibold tracking-tight text-gray-900 dark:text-white">Training</h1>
+          <p class="mt-2 text-base text-gray-500 dark:text-gray-400">Select a category to start training</p>
+        </div>
+        <button id="dark-mode-toggle" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition" aria-label="Toggle dark mode">
+          <svg id="icon-sun" class="w-5 h-5 hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m8.66-13.66l-.71.71M4.05 19.95l-.71.71M21 12h-1M4 12H3m16.66 7.66l-.71-.71M4.05 4.05l-.71-.71M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+          <svg id="icon-moon" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z"/></svg>
+        </button>
+      </div>
     </header>
 
     <div class="max-w-3xl mx-auto w-full mt-10 mb-8 px-4">
@@ -86,10 +96,10 @@
 
     <div id="quiz-history" class="max-w-3xl mx-auto w-full mb-8 px-4 hidden">
       <p class="text-xs uppercase tracking-wide text-gray-400 mb-4 text-center">Recent activity</p>
-      <div class="bg-white border border-gray-200 rounded-xl overflow-hidden">
+      <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
         <div id="quiz-history-list"></div>
-        <div class="px-4 py-3 text-center border-t border-gray-100">
-          <button id="clear-history" class="text-xs text-gray-400 hover:text-gray-600 cursor-pointer">Clear history</button>
+        <div class="px-4 py-3 text-center border-t border-gray-100 dark:border-gray-700">
+          <button id="clear-history" class="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer">Clear history</button>
         </div>
       </div>
     </div>
@@ -116,12 +126,12 @@
             .map(function (entry, i) {
               const d = new Date(entry.date);
               const dateStr = d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-              const border = i < history.length - 1 ? "border-b border-gray-100" : "";
+              const border = i < history.length - 1 ? "border-b border-gray-100 dark:border-gray-700" : "";
               return (
                 '<div class="flex items-center justify-between px-4 py-3 ' + border + '">' +
                   '<span class="text-gray-400 text-sm w-20">' + dateStr + "</span>" +
-                  '<span class="text-gray-700 font-medium text-sm flex-1">' + entry.category + "</span>" +
-                  '<span class="text-sm text-gray-600">' + entry.score + "/" + entry.total + "</span>" +
+                  '<span class="text-gray-700 dark:text-gray-300 font-medium text-sm flex-1">' + entry.category + "</span>" +
+                  '<span class="text-sm text-gray-600 dark:text-gray-400">' + entry.score + "/" + entry.total + "</span>" +
                 "</div>"
               );
             })
@@ -138,18 +148,40 @@
     </script>
     </main>
 
+    <script>
+      (function () {
+        const toggle = document.getElementById("dark-mode-toggle");
+        const iconSun = document.getElementById("icon-sun");
+        const iconMoon = document.getElementById("icon-moon");
+        function applyTheme(dark) {
+          document.documentElement.classList.toggle("dark", dark);
+          iconSun.classList.toggle("hidden", !dark);
+          iconMoon.classList.toggle("hidden", dark);
+        }
+        const stored = localStorage.getItem("theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        applyTheme(stored === "dark" || (!stored && prefersDark));
+        toggle.addEventListener("click", function () {
+          const isDark = document.documentElement.classList.toggle("dark");
+          localStorage.setItem("theme", isDark ? "dark" : "light");
+          iconSun.classList.toggle("hidden", !isDark);
+          iconMoon.classList.toggle("hidden", isDark);
+        });
+      })();
+    </script>
+
     <footer class="footer">
-      <p class="text-gray-500 text-sm">
+      <p class="text-gray-500 dark:text-gray-400 text-sm">
         Help improve the questionnaires:
         <a
           href="https://github.com/efficience-it/efficience-it.github.io"
-          class="text-gray-500 hover:text-gray-700 underline"
+          class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 underline"
           >This Website</a
         >
         &middot;
         <a
           href="https://github.com/efficience-it/docker-practice"
-          class="text-gray-500 hover:text-gray-700 underline"
+          class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 underline"
           >Docker&reg; Questions</a
         >
       </p>

--- a/quizz_docker.html
+++ b/quizz_docker.html
@@ -12,6 +12,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
     <script>
       tailwind.config = {
+        darkMode: 'class',
         theme: {
           extend: {
             fontFamily: {
@@ -40,37 +41,42 @@
             border: 1px solid #e5e7eb;
             border-radius: 0.75rem;
         }
+        .dark #questions-container > div,
+        .dark #questions-container > div.mb-4 {
+            background: #1f2937;
+            border-color: #374151;
+        }
     </style>
 </head>
-<body class="bg-stone-50 px-2 sm:px-4 font-sans">
+<body class="bg-stone-50 dark:bg-gray-900 px-2 sm:px-4 font-sans dark:text-gray-200">
 <noscript>
     <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M5HHV7GC"
             height="0" width="0" style="display:none;visibility:hidden"></iframe>
 </noscript>
-<header class="bg-white border-b border-gray-200 p-4 text-center mb-0">
+<header class="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 p-4 text-center mb-0">
     <div class="max-w-3xl mx-auto flex items-center justify-between">
-        <a href="index.html" class="text-gray-400 hover:text-gray-600 text-sm flex items-center gap-1 transition duration-200">
+        <a href="index.html" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-sm flex items-center gap-1 transition duration-200">
             &larr; Back to categories
         </a>
-        <h1 id="quiz-title" class="text-xl sm:text-2xl font-semibold tracking-tight text-gray-900"></h1>
+        <h1 id="quiz-title" class="text-xl sm:text-2xl font-semibold tracking-tight text-gray-900 dark:text-white"></h1>
         <span class="w-32"></span>
     </div>
 </header>
-<div class="max-w-3xl mx-auto bg-white border border-gray-200 rounded-b-xl px-3 sm:px-6 py-6 pb-16">
+<div class="max-w-3xl mx-auto bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-b-xl px-3 sm:px-6 py-6 pb-16">
     <div id="score" class="text-xl text-center m-4"></div>
     <div id="progress" class="mb-4">
         <div class="flex justify-between text-sm text-gray-500 mb-1">
             <span id="progress-text">0/0 answered</span>
         </div>
-        <div class="w-full bg-gray-100 rounded-full h-1.5">
+        <div class="w-full bg-gray-100 dark:bg-gray-700 rounded-full h-1.5">
             <div id="progress-bar" class="bg-indigo-600 h-1.5 rounded-full transition-all duration-300" style="width: 0%"></div>
         </div>
     </div>
     <form id="quiz-form">
         <div id="questions-container" class="pb-16"></div>
-        <div class="fixed bottom-0 left-0 w-full bg-white/80 backdrop-blur-sm border-t border-gray-200 p-2 flex justify-center space-x-2">
+        <div class="fixed bottom-0 left-0 w-full bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border-t border-gray-200 dark:border-gray-700 p-2 flex justify-center space-x-2">
             <button type="button" id="restart-quiz"
-                    class="px-4 py-2 bg-white text-gray-700 font-medium rounded-lg border border-gray-300 hover:bg-gray-50 transition duration-200 text-sm">
+                    class="px-4 py-2 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 font-medium rounded-lg border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-200 text-sm">
                 Restart
             </button>
             <button type="submit"
@@ -80,6 +86,15 @@
         </div>
     </form>
 </div>
+<script>
+  (function () {
+    var stored = localStorage.getItem("theme");
+    var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    if (stored === "dark" || (!stored && prefersDark)) {
+      document.documentElement.classList.add("dark");
+    }
+  })();
+</script>
 <script src="./assets/js/common.js"></script>
 <script src="./assets/js/quizz_docker.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Add dark mode toggle button in index.html header (sun/moon icon)
- Persist preference in localStorage, respect `prefers-color-scheme` as default
- Apply `dark:` Tailwind classes to both index.html and quizz_docker.html
- Quiz page reads theme from localStorage on load to avoid flash

## Test plan
- [ ] Open index page → respects system preference
- [ ] Click toggle → switches to dark/light mode
- [ ] Navigate to quiz → dark mode persists
- [ ] Reload → preference is remembered

Closes #28