### PR TITLE
feat: add SEO meta tags (#29)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,15 @@
     <script src="assets/js/gtag.js"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Test Categories</title>
+    <title>Docker Training — Practice Quizzes for DCA Certification</title>
+    <meta name="description" content="Free practice quizzes for the Docker DCA certification. Train by topic: orchestration, networking, security, storage, and more." />
+    <meta property="og:title" content="Docker Training — Practice Quizzes for DCA Certification" />
+    <meta property="og:description" content="Free practice quizzes for the Docker DCA certification. Train by topic: orchestration, networking, security, storage, and more." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://efficience-it.github.io/" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Docker Training — Practice Quizzes for DCA Certification" />
+    <meta name="twitter:description" content="Free practice quizzes for the Docker DCA certification." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/quizz_docker.html
+++ b/quizz_docker.html
@@ -4,7 +4,12 @@
     <script src="assets/js/gtag.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title id="page-title">Quiz Docker&reg;</title>
+    <title id="page-title">Quiz — Docker DCA Practice</title>
+    <meta name="description" content="Practice quiz for Docker DCA certification. Answer questions and get instant feedback." />
+    <meta property="og:title" content="Docker DCA Practice Quiz" />
+    <meta property="og:description" content="Practice quiz for Docker DCA certification. Answer questions and get instant feedback." />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- Add descriptive page titles to both pages
- Add meta description, Open Graph and Twitter Card tags
- index.html and quizz_docker.html updated

## Test plan
- [x] Inspect page source → meta tags present
- [x] Share URL on social media / Slack → preview shows title and description

Closes #29