### PR TITLE
feat: improve accessibility (#30)

### DIFF
--- a/assets/js/quizz_docker.js
+++ b/assets/js/quizz_docker.js
@@ -299,15 +299,16 @@ function generateQuestionHTML(question, index) {
                     <h5 class="question-header flex justify-between items-center font-semibold text-gray-700" 
                         data-answers='${escapeHTML(JSON.stringify(answers.filter((a) => a.correct).map((a) => a.value)))}'>
                         <span class="question-header-title">${escapeHTML(question.question)}</span>
-                        <span class="copy-uuid self-end text-sm text-gray-500 cursor-pointer hover:text-gray-700" 
+                        <button type="button" class="copy-uuid self-end text-sm text-gray-500 cursor-pointer hover:text-gray-700"
                               title="Click to copy UUID: ${question.uuid}"
-                              data-uuid="${question.uuid}">ℹ️</span>
+                              aria-label="Copy question UUID"
+                              data-uuid="${question.uuid}">ℹ️</button>
                     </h5>
                     <div class="question-body mt-2">
                         <div class="answers-container mt-2">${optionsHTML}</div>
                         <div class="hidden mt-2 p-2 rounded answer-section">
                             <span class="answer-section-text"></span>
-                            🔗 <a href="${question.help}" target="_blank" class="text-blue-600 underline">View source</a>
+                            🔗 <a href="${question.help}" target="_blank" rel="noopener noreferrer" class="text-blue-600 underline" aria-label="View source for this question">View source</a>
                         </div>
                     </div>
                 </div>`;

--- a/quizz_docker.html
+++ b/quizz_docker.html
@@ -43,6 +43,7 @@
     </style>
 </head>
 <body class="bg-stone-50 px-2 sm:px-4 font-sans">
+<a href="#questions-container" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:bg-indigo-600 focus:text-white focus:px-4 focus:py-2 focus:rounded-lg focus:z-50">Skip to questions</a>
 <noscript>
     <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M5HHV7GC"
             height="0" width="0" style="display:none;visibility:hidden"></iframe>
@@ -57,10 +58,10 @@
     </div>
 </header>
 <div class="max-w-3xl mx-auto bg-white border border-gray-200 rounded-b-xl px-3 sm:px-6 py-6 pb-16">
-    <div id="score" class="text-xl text-center m-4"></div>
+    <div id="score" class="text-xl text-center m-4" aria-live="polite"></div>
     <div id="progress" class="mb-4">
         <div class="flex justify-between text-sm text-gray-500 mb-1">
-            <span id="progress-text">0/0 answered</span>
+            <span id="progress-text" aria-live="polite">0/0 answered</span>
         </div>
         <div class="w-full bg-gray-100 rounded-full h-1.5">
             <div id="progress-bar" class="bg-indigo-600 h-1.5 rounded-full transition-all duration-300" style="width: 0%"></div>


### PR DESCRIPTION
## Summary
- Add `aria-live="polite"` to score and progress elements for screen readers
- Add `aria-label` to UUID copy button and View source links
- Change copy-uuid from `<span>` to `<button>` for keyboard accessibility
- Add `rel="noopener noreferrer"` to external links
- Add skip-to-content link for keyboard navigation

## Test plan
- [x] Tab through quiz page → skip link appears on focus
- [x] Screen reader announces score changes after validation
- [x] UUID copy button is keyboard-accessible (Enter/Space)

Closes #30