### PR TITLE
perf: optimize DOM rendering (#31)

### DIFF
--- a/assets/js/quizz_docker.js
+++ b/assets/js/quizz_docker.js
@@ -227,9 +227,10 @@ function displayQuestions(questions) {
   container.innerHTML = "";
 
   shuffleArray(questions);
-  questions.slice(0, MAX_QUESTIONS).forEach((question, index) => {
-      container.innerHTML += generateQuestionHTML(question, index);
-    });
+  container.innerHTML = questions
+    .slice(0, MAX_QUESTIONS)
+    .map((question, index) => generateQuestionHTML(question, index))
+    .join("");
 
   // Progress tracking
   const totalQuestions = container.querySelectorAll(".question-body").length;


### PR DESCRIPTION
## Summary
- Replace `innerHTML +=` inside a forEach loop with a single `innerHTML =` using `.map().join()`
- Avoids a DOM reflow on each iteration (up to 20 reflows reduced to 1)

## Test plan
- [ ] Open a quiz → questions render correctly
- [ ] All interactions (answer selection, validation) still work

Closes #31