### PR TITLE
perf: cache questions in sessionStorage (#32)

### DIFF
--- a/assets/js/quizz_docker.js
+++ b/assets/js/quizz_docker.js
@@ -200,12 +200,25 @@ async function fetchGeneralQuiz() {
 }
 
 async function fetchYaml(url) {
+  const cacheKey = "yamlCache:" + url;
+  try {
+    const cached = sessionStorage.getItem(cacheKey);
+    if (cached) return JSON.parse(cached);
+  } catch (e) {
+    // sessionStorage unavailable or corrupted, continue with fetch
+  }
   try {
     const response = await fetch(url);
     if (!response.ok) throw new Error(`Fetch failed: ${url}`);
     const yamlText = await response.text();
     const jsonData = jsyaml.load(yamlText);
-    return jsonData.questions || [];
+    const questions = jsonData.questions || [];
+    try {
+      sessionStorage.setItem(cacheKey, JSON.stringify(questions));
+    } catch (e) {
+      // sessionStorage full, ignore
+    }
+    return questions;
   } catch (error) {
     console.error(error);
     return [];


### PR DESCRIPTION
## Summary
- Cache parsed YAML questions in sessionStorage keyed by URL
- Subsequent quiz loads within the same session skip network requests
- Graceful fallback if sessionStorage is unavailable or full

## Test plan
- [ ] Open a quiz → questions load from network (first time)
- [ ] Click Restart → questions load instantly from cache
- [ ] Open DevTools > Application > Session Storage → cached entries visible
- [ ] Close tab and reopen → fresh fetch (sessionStorage cleared)

Closes #32